### PR TITLE
Update for Django 4.2 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.sqp
 build/
 dist/
+.python-version

--- a/djangosaml2/signals.py
+++ b/djangosaml2/signals.py
@@ -15,6 +15,5 @@
 import django.dispatch
 
 
-pre_user_save = django.dispatch.Signal(providing_args=['attributes',
-                                                       'user_modified'])
-post_authenticated = django.dispatch.Signal(providing_args=['session_info'])
+pre_user_save = django.dispatch.Signal()
+post_authenticated = django.dispatch.Signal()

--- a/djangosaml2/tests/__init__.py
+++ b/djangosaml2/tests/__init__.py
@@ -31,10 +31,7 @@ except ImportError:
 from django.template import Template, Context
 from django.test import TestCase
 from django.test.client import RequestFactory
-try:
-    from django.utils.encoding import force_text
-except ImportError:
-    from django.utils.text import force_text
+from django.utils.encoding import force_str
 try:
     from django.utils.six.moves.urllib.parse import urlparse, parse_qs
 except ImportError:
@@ -258,7 +255,7 @@ class SAML2Tests(TestCase):
         url = urlparse(location)
         # as the RelayState is empty we have redirect to LOGIN_REDIRECT_URL
         self.assertEqual(url.path, settings.LOGIN_REDIRECT_URL)
-        self.assertEqual(force_text(new_user.id), self.client.session[SESSION_KEY])
+        self.assertEqual(force_str(new_user.id), self.client.session[SESSION_KEY])
 
     def test_assertion_consumer_service_no_session(self):
         settings.SAML_CONFIG = conf.create_conf(

--- a/djangosaml2/tests/urls.py
+++ b/djangosaml2/tests/urls.py
@@ -12,20 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.contrib import admin
+from django.urls import re_path
 
 from djangosaml2 import views
 
 
 urlpatterns = [
-    url(r'^login/$', views.login, name='saml2_login'),
-    url(r'^acs/$', views.assertion_consumer_service, name='saml2_acs'),
-    url(r'^logout/$', views.logout, name='saml2_logout'),
-    url(r'^ls/$', views.logout_service, name='saml2_ls'),
-    url(r'^ls/post/$', views.logout_service_post, name='saml2_ls_post'),
-    url(r'^metadata/$', views.metadata, name='saml2_metadata'),
+    re_path(r'^login/$', views.login, name='saml2_login'),
+    re_path(r'^acs/$', views.assertion_consumer_service, name='saml2_acs'),
+    re_path(r'^logout/$', views.logout, name='saml2_logout'),
+    re_path(r'^ls/$', views.logout_service, name='saml2_ls'),
+    re_path(r'^ls/post/$', views.logout_service_post, name='saml2_ls_post'),
+    re_path(r'^metadata/$', views.metadata, name='saml2_metadata'),
 
     # this is needed for the tests
-    url(r'^admin/', include(admin.site.urls)),
+    re_path(r'^admin/', include(admin.site.urls)),
 ]

--- a/djangosaml2/urls.py
+++ b/djangosaml2/urls.py
@@ -13,15 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.conf.urls import url
+from django.urls import re_path
 from djangosaml2 import views
 
 
 urlpatterns = [
-    url(r'^login/$', views.login, name='saml2_login'),
-    url(r'^acs/$', views.assertion_consumer_service, name='saml2_acs'),
-    url(r'^logout/$', views.logout, name='saml2_logout'),
-    url(r'^ls/$', views.logout_service, name='saml2_ls'),
-    url(r'^ls/post/$', views.logout_service_post, name='saml2_ls_post'),
-    url(r'^metadata/$', views.metadata, name='saml2_metadata'),
+    re_path(r'^login/$', views.login, name='saml2_login'),
+    re_path(r'^acs/$', views.assertion_consumer_service, name='saml2_acs'),
+    re_path(r'^logout/$', views.logout, name='saml2_logout'),
+    re_path(r'^ls/$', views.logout_service, name='saml2_ls'),
+    re_path(r'^ls/post/$', views.logout_service_post, name='saml2_ls_post'),
+    re_path(r'^metadata/$', views.metadata, name='saml2_metadata'),
 ]

--- a/djangosaml2/utils.py
+++ b/djangosaml2/utils.py
@@ -15,7 +15,7 @@
 import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.module_loading import import_string
 from saml2.s_utils import UnknownSystemEntity
 
@@ -84,7 +84,7 @@ def fail_acs_response(request, *args, **kwargs):
 
 def is_safe_url_compat(url, allowed_hosts=None, require_https=False):
     if django.VERSION >= (1, 11):
-        return is_safe_url(url, allowed_hosts=allowed_hosts, require_https=require_https)
+        return url_has_allowed_host_and_scheme(url, allowed_hosts=allowed_hosts, require_https=require_https)
     assert len(allowed_hosts) == 1
     host = allowed_hosts.pop()
-    return is_safe_url(url, host=host)
+    return url_has_allowed_host_and_scheme(url, host=host)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if sys.version_info < (3, 4):
 
 setup(
     name='djangosaml2',
-    version='0.18.1',
+    version='0.18.1.post1',
     description='pysaml2 integration for Django',
     long_description=read('README.rst'),
     classifiers=[

--- a/tests/testprofiles/urls.py
+++ b/tests/testprofiles/urls.py
@@ -1,7 +1,9 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import re_path
+
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^saml2/', include('djangosaml2.urls')),
-    url(r'^admin/', admin.site.urls),
+    re_path(r'^saml2/', include('djangosaml2.urls')),
+    re_path(r'^admin/', admin.site.urls),
 ]


### PR DESCRIPTION
# Compatibility fixes for Django 4.2

## Django 4.0.10
* [Django 4.0 deprecations](https://docs.djangoproject.com/en/5.0/internals/deprecation/#deprecation-removed-in-4-0):
* See the [Django 3.0 release notes](https://docs.djangoproject.com/en/5.0/releases/3.0/#deprecated-features-3-0) for more details on these changes.

- [x] **django.utils.encoding.force_text()** and **smart_text()** will be removed.  The aliases are  force_str() and smart_str().
- [x] **django.utils.http.urlquote()**, **urlquote_plus()**, **urlunquote()**, and **urlunquote_plus()** will be removed.
- [x] **django.utils.translation.ugettext()**, **ugettext_lazy()**, **ugettext_noop()**, **ungettext()**, and **ungettext_lazy()** will be removed.
- [x]  **django.views.i18n.set_language()** will no longer set the user language in **request.session** (key **django.utils.translation.LANGUAGE_SESSION_KEY**). 
- [x] **alias=None** will be required in the signature of **django.db.models.Expression.get_group_by_cols()** subclasses.
- [x] **django.utils.text.unescape_entities()** will be removed.
- [x] **django.utils.http.is_safe_url()** will be removed.

* See the [Django 3.1 release notes](https://docs.djangoproject.com/en/5.0/releases/3.1/#deprecated-features-3-1) for more details on these changes.
- [x] **The PASSWORD_RESET_TIMEOUT_DAYS** setting will be removed.
- [x] The undocumented usage of the **isnull** lookup with non-boolean values as the right-hand side will no longer be allowed.
- [x] The **django.db.models.query_utils.InvalidQuery** exception class will be removed.
- [x] The **django-admin.py** entry point will be removed.
- [x] Support for the pre-Django 3.1 encoding format of cookies values used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] The **providing_args** argument for **django.dispatch.Signal** will be removed.
- [x] The **length** argument for **django.utils.crypto.get_random_string()** will be required.
- [x] The model **NullBooleanField** will be removed. A stub field will remain for compatibility with historical migrations. 
- [x] The model **django.contrib.postgres.fields.JSONField** will be removed. A stub field will remain for compatibility with historical migrations.
- [x] **django.contrib.postgres.forms.JSONField**, **django.contrib.postgres.fields.jsonb.KeyTransform**, and **django.contrib.postgres.fields.jsonb.KeyTextTransform** will be removed.
- [x] The **DEFAULT_HASHING_ALGORITHM** transitional setting will be removed.
- [x] Support for passing raw column aliases to **QuerySet.order_by()** will be removed.
- [x] **django.conf.urls.url()** will be removed.  It's an alias of **django.urls.re_path()**.
- [x] The **get_response** argument for **django.utils.deprecation.MiddlewareMixin.__init__()** will be required and won’t accept **None**.
- [x] The **list** message for **ModelMultipleChoiceField** will be removed.
- [x] The **HttpRequest.is_ajax()** method will be removed.
- [x] The **{% ifequal %}** and **{% ifnotequal %}** template tags will be removed.

### pre-Django 3.1 SHA-1
- [x] Support for the pre-Django 3.1 password reset tokens in the admin site (that use the SHA-1 hashing algorithm) will be removed.
- [x] Support for the pre-Django 3.1 encoding format of sessions will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.Signer** signatures (encoded with the SHA-1 algorithm) will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.dumps()** signatures (encoded with the SHA-1 algorithm) in **django.core.signing.loads()** will be removed.
- [x] Support for the pre-Django 3.1 user sessions (that use the SHA-1 algorithm) will be removed.

## Django 4.1.13
See the [Django 3.2 release notes](https://docs.djangoproject.com/en/5.0/releases/3.2/#deprecated-features-3-2) for more details on these changes.

- [x] Support for assigning objects which don’t support creating deep copies with **copy.deepcopy()** to class attributes in **TestCase.setUpTestData()** will be removed.
- [x] The **whitelist** argument and **domain_whitelist** attribute of **django.core.validators.EmailValidator** will be removed.
- [x] **TransactionTestCase.assertQuerysetEqual()** will no longer automatically call **repr()** on a queryset when compared to string values.
- [x] Support for the pre-Django 3.2 format of messages used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] **BaseCommand.requires_system_checks** won’t support boolean values. Use '__all__' instead of True, and [] (an empty list) instead of False.
- [x] **django.core.cache.backends.memcached.MemcachedCache** will be removed.
- [x] The **default_app_config** module variable will be removed. 
